### PR TITLE
Add survival timer and game over overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <title>Game</title>
 </head>
 <body>
-  <h1>Game Entry Point</h1>
+  <div id="score" style="position:absolute;top:10px;left:10px;font-size:24px;font-family:sans-serif"></div>
   <script src="bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track elapsed survival time and display it in a #score UI element
- detect dog-obstacle collisions and stop game
- show game-over overlay with final score

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898314230188329acb07b468e80de18