### PR TITLE
Add responsive canvas with orientation handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 public/bundle.js
 public/assets/
+public/styles.css
 assets/images/dog_sprite.png

--- a/public/index.html
+++ b/public/index.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8" />
   <title>Game</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div id="score" style="position:absolute;top:10px;left:10px;font-size:24px;font-family:sans-serif"></div>
+  <div id="score"></div>
+  <canvas id="gameCanvas"></canvas>
   <script src="bundle.js"></script>
 </body>
 </html>

--- a/src/game.js
+++ b/src/game.js
@@ -13,14 +13,19 @@ const DOG_WIDTH = 50;
 const DOG_HEIGHT = 50;
 
 export function startGame() {
+  const canvas = document.getElementById('gameCanvas');
+  const ctx = canvas.getContext('2d');
+
+  function resizeCanvas() {
+    canvas.width = canvas.clientWidth;
+    canvas.height = canvas.clientHeight;
+  }
+  window.addEventListener('resize', resizeCanvas);
+  window.addEventListener('orientationchange', resizeCanvas);
+  resizeCanvas();
+
   const dog = new Image();
   dog.src = `data:image/png;base64,${dogSpriteBase64.trim()}`;
-  dog.style.position = 'absolute';
-  dog.style.left = '50px';
-  dog.style.bottom = '0px';
-  dog.style.width = `${DOG_WIDTH}px`;
-  dog.style.height = `${DOG_HEIGHT}px`;
-  document.body.appendChild(dog);
 
   const scoreElement = document.getElementById('score');
   scoreElement.textContent = '0.00';
@@ -36,7 +41,7 @@ export function startGame() {
 
   function spawnObstacle() {
     const height = randomRange(OBSTACLE_MIN_HEIGHT, OBSTACLE_MAX_HEIGHT);
-    const obstacle = new Obstacle(height, OBSTACLE_SPEED);
+    const obstacle = new Obstacle(height, OBSTACLE_SPEED, canvas);
     obstacles.push(obstacle);
   }
 
@@ -51,17 +56,11 @@ export function startGame() {
     }
 
     obstacles.forEach((obstacle) => obstacle.update());
-    obstacles = obstacles.filter((obstacle) => {
-      if (obstacle.isOffScreen()) {
-        obstacle.remove();
-        return false;
-      }
-      return true;
-    });
+    obstacles = obstacles.filter((obstacle) => !obstacle.isOffScreen());
 
     const dogBounds = {
-      left: parseInt(dog.style.left, 10),
-      right: parseInt(dog.style.left, 10) + DOG_WIDTH,
+      left: 50,
+      right: 50 + DOG_WIDTH,
       bottom: y,
       top: y + DOG_HEIGHT,
     };
@@ -87,8 +86,12 @@ export function startGame() {
         velocity = 0;
         onGround = true;
       }
-      dog.style.bottom = `${y}px`;
     }
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(dog, 50, canvas.height - DOG_HEIGHT - y, DOG_WIDTH, DOG_HEIGHT);
+    obstacles.forEach((obstacle) => obstacle.draw(ctx, canvas.height));
+
     if (!gameOver) {
       requestAnimationFrame(update);
     }
@@ -105,7 +108,7 @@ export function startGame() {
 
   function endGame() {
     gameOver = true;
-    window.removeEventListener('pointerdown', jump);
+    canvas.removeEventListener('pointerdown', jump);
     const finalScore = scoreElement.textContent;
     const overlay = document.createElement('div');
     overlay.style.position = 'absolute';
@@ -121,7 +124,7 @@ export function startGame() {
     document.body.appendChild(overlay);
   }
 
-  window.addEventListener('pointerdown', jump);
+  canvas.addEventListener('pointerdown', jump);
   requestAnimationFrame(update);
 }
 

--- a/src/objects/Obstacle.js
+++ b/src/objects/Obstacle.js
@@ -1,22 +1,18 @@
 export default class Obstacle {
-  constructor(height, speed) {
+  constructor(height, speed, canvas) {
     this.width = 30;
     this.height = height;
     this.speed = speed;
-    this.x = window.innerWidth;
-    this.element = document.createElement('div');
-    this.element.style.position = 'absolute';
-    this.element.style.left = `${this.x}px`;
-    this.element.style.bottom = '0px';
-    this.element.style.width = `${this.width}px`;
-    this.element.style.height = `${this.height}px`;
-    this.element.style.backgroundColor = 'red';
-    document.body.appendChild(this.element);
+    this.x = canvas.width;
   }
 
   update() {
     this.x -= this.speed;
-    this.element.style.left = `${this.x}px`;
+  }
+
+  draw(ctx, canvasHeight) {
+    ctx.fillStyle = 'red';
+    ctx.fillRect(this.x, canvasHeight - this.height, this.width, this.height);
   }
 
   isOffScreen() {
@@ -30,9 +26,5 @@ export default class Obstacle {
       top: this.height,
       bottom: 0,
     };
-  }
-
-  remove() {
-    this.element.remove();
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,44 @@
+body, html {
+  margin: 0;
+  padding: 0;
+}
+
+#score {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  font-family: sans-serif;
+}
+
+#gameCanvas {
+  display: block;
+  margin: 0 auto;
+  background: #ffffff;
+  width: 100vw;
+  height: 60vh;
+}
+
+/* Larger viewports (desktop) */
+@media (min-width: 768px) {
+  #gameCanvas {
+    width: 800px;
+    height: 450px;
+  }
+  #score {
+    font-size: 24px;
+  }
+}
+
+/* Narrow viewports (mobile) */
+@media (max-width: 767px) {
+  #score {
+    font-size: 18px;
+  }
+}
+
+/* Orientation adjustments */
+@media (orientation: landscape) and (max-width: 767px) {
+  #gameCanvas {
+    height: 80vh;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,10 @@ module.exports = {
   },
   plugins: [
     new CopyWebpackPlugin({
-      patterns: [{ from: 'assets', to: 'assets' }],
+      patterns: [
+        { from: 'assets', to: 'assets' },
+        { from: 'src/styles.css', to: 'styles.css' },
+      ],
     }),
   ],
 };


### PR DESCRIPTION
## Summary
- Add `styles.css` with media queries to scale canvas and score UI for mobile and desktop layouts.
- Render gameplay onto a `<canvas>` element with orientation-aware resizing and touch input handling.
- Convert obstacle rendering to canvas and copy the new stylesheet during builds.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68983c379b58832995a39b0f365a7de3