### PR TITLE
chore: update artifact actions for Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 
@@ -37,4 +37,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- use actions/upload-pages-artifact@v2 and actions/deploy-pages@v2 to avoid deprecated upload-artifact v3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689840f4a32483298c1ee192d379990b