### PR TITLE
Deploy README to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Deploy README to GitHub Pages
 
 on:
   push:
@@ -19,12 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - run: npm ci
-      - run: npm test
-      - run: npm run build
+      - name: Prepare README site
+        run: |
+          mkdir public
+          cp README.md public/index.md
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./public


### PR DESCRIPTION
## Summary
- Deploy README.md as the GitHub Pages site instead of the built game.

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: apt-get: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689858542f5883298edf75ed02dd3ae5