### PR TITLE
Ensure public directory creation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Prepare README site
         run: |
-          mkdir public
+          mkdir -p public
           cp README.md public/index.md
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- avoid failure if `public` directory exists during deploy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68985aa1a98483299958c709bca2b434